### PR TITLE
Add callout that external subschema approach is not prohibited.

### DIFF
--- a/spec/Section 1 -- Overview.md
+++ b/spec/Section 1 -- Overview.md
@@ -42,9 +42,9 @@ The GraphQL Composite Schemas specification has a number of design principles:
   intentions and minimize reliance on inference and convention.
 
 Note: Although the GraphQL Composite Schemas specification does not describe how
-to combine arbitrary schemas, as noted above, tooling may be built to transform
-existing or external schemas into compliant _source schemas_. Details of
-building such tooling is beyond the scope of this specification.
+to combine arbitrary schemas, tooling may be built to transform existing or
+external schemas into compliant _source schemas_. Details of building such
+tooling is beyond the scope of this specification.
 
 To enable greater interoperability between different implementations of tooling
 and gateways, this specification focuses on two core components: schema

--- a/spec/Section 1 -- Overview.md
+++ b/spec/Section 1 -- Overview.md
@@ -17,9 +17,10 @@ The GraphQL Composite Schemas specification has a number of design principles:
   from the start. Each source schema defines the types and fields it is
   responsible for serving within the context of the larger schema, referencing
   and extending what is provided by other source schemas. The GraphQL Composite
-  Schemas specification does not describe how to combine arbitrary schemas, even
-  as tooling may be able to transform existing or external schemas into
-  compliant _source schemas_.
+  Schemas specification does not describe how to combine arbitrary schemas.  
+  Note: Tooling may be built to transform existing or external schemas into
+  compliant _source schemas_, but details of building such tooling is beyond the
+  scope of this specification.
 
 - **Collaborative**: The GraphQL Composite Schemas specification is explicitly
   designed around team collaboration. By building on a principled composition

--- a/spec/Section 1 -- Overview.md
+++ b/spec/Section 1 -- Overview.md
@@ -18,10 +18,7 @@ The GraphQL Composite Schemas specification has a number of design principles:
   responsible for serving within the context of the larger schema, referencing
   and extending that which is provided by other source schemas. The GraphQL
   Composite Schemas specification does not describe how to combine arbitrary
-  schemas.  
-  Note: Tooling may be built to transform existing or external schemas into
-  compliant _source schemas_, but details of building such tooling is beyond the
-  scope of this specification.
+  schemas.
 
 - **Collaborative**: The GraphQL Composite Schemas specification is explicitly
   designed around team collaboration. By building on a principled composition
@@ -43,6 +40,11 @@ The GraphQL Composite Schemas specification has a number of design principles:
   avoid ambiguities that can lead to confusing failures as the system grows, the
   GraphQL Composite Schemas specification prefers to be explicit about
   intentions and minimize reliance on inference and convention.
+
+Note: Although the GraphQL Composite Schemas specification does not describe how
+to combine arbitrary schemas, as noted above, tooling may be built to transform
+existing or external schemas into compliant _source schemas_. Details of
+building such tooling is beyond the scope of this specification.
 
 To enable greater interoperability between different implementations of tooling
 and gateways, this specification focuses on two core components: schema

--- a/spec/Section 1 -- Overview.md
+++ b/spec/Section 1 -- Overview.md
@@ -17,7 +17,9 @@ The GraphQL Composite Schemas specification has a number of design principles:
   from the start. Each source schema defines the types and fields it is
   responsible for serving within the context of the larger schema, referencing
   and extending what is provided by other source schemas. The GraphQL Composite
-  Schemas specification does not describe how to combine arbitrary schemas.
+  Schemas specification does not describe how to combine arbitrary schemas, even
+  as tooling may be able to transform existing or external schemas into
+  compliant _source schemas_.
 
 - **Collaborative**: The GraphQL Composite Schemas specification is explicitly
   designed around team collaboration. By building on a principled composition


### PR DESCRIPTION
I'm overall not convinced that the way the specification is designed should match how it is used. Most teams/groups using composition *may* be "in control" of *all* of the different subchemas/source schemas, but I'm not convinced that this definitely so; perhaps they are "in control" of most of them but want to link to popular 3rd party APIs, Github/Stripe, etc. Since the problem of connecting arbitrary subschemas is a superset of what the specification currently proposes, I think it would make sense to start there, as otherwise the specialized case crowds out the more general.

So I would be in favor of a more generic specification that describes how multiple GraphQL schemas can be composed, and then leave room for additional tooling that might be helpful for those teams that are truly "in control" of all of their subschemas, and am leaning against the vision suggested here.

On the other hand, this PR introduces a small change that just highlights that it should be possible to transform arbitrary schemas into compliant source schemas, which I think might bridge the overall gap.