### PR TITLE
Introduce Key Directive

### DIFF
--- a/spec/Section 2 -- Source Schema.md
+++ b/spec/Section 2 -- Source Schema.md
@@ -140,6 +140,10 @@ The `@key` directive designates an object type as an entity and specifies its ke
 directive @key(fields: FieldSet!) repeatable on OBJECT | INTERFACE
 ```
 
+**Arguments:**
+
+- `fields`: Represents a GraphQL selections set syntax that refers to fields of the annotated type that represent a unique key to resolve the same type.
+
 ### @shareable
 
 ```graphql

--- a/spec/Section 2 -- Source Schema.md
+++ b/spec/Section 2 -- Source Schema.md
@@ -132,6 +132,14 @@ extend type Review {
 - `coordinate`: Represents a schema coordinate that refers to a type system
   member.
 
+### @key
+
+The `@key` directive designates an object type as an entity and specifies its key fields (a set of fields that the _source schema_ can use to uniquely identify any instance of the entity).
+
+```graphql
+directive @key(fields: FieldSet!) repeatable on OBJECT | INTERFACE
+```
+
 ### @shareable
 
 ```graphql


### PR DESCRIPTION
This PR introduces the `@key` directive to the spec which is used to declare the keys of an entity by which it can be fetched from a source schema.