### PR TITLE
Adds Semantical Equivalence of Types Validation Rule

### DIFF
--- a/cspell.yml
+++ b/cspell.yml
@@ -31,4 +31,3 @@ words:
 ignoreWords:
   - Aremergeable
   - FXXXX
-  - TYPE_KIND_NOT_MERGABLE

--- a/cspell.yml
+++ b/cspell.yml
@@ -31,3 +31,4 @@ words:
 ignoreWords:
   - Aremergeable
   - FXXXX
+  - TYPE_KIND_NOT_MERGABLE

--- a/spec/Section 4 -- Composition.md
+++ b/spec/Section 4 -- Composition.md
@@ -25,7 +25,8 @@ run in sequence to produce the composite execution schema.
 - Let {typesByName} be an empty unordered map of sets.
 - For each named type {type} across all source schemas:
   - Let {name} be the name of {type}.
-  - Let {set} be the set in {typesByName} for {name}; if no such set exists, create it as an empty set.
+  - Let {set} be the set in {typesByName} for {name}; if no such set exists,
+    create it as an empty set.
   - Add {type} to {set}.
 - For each {typesByName} as {name} and {types}:
   - Each pair of types in {types} must have the same kind.
@@ -33,8 +34,11 @@ run in sequence to produce the composite execution schema.
 **Explanatory Text**
 
 The GraphQL Composite Schemas specification considers types with the same name
-across source schemas as semantically equivalent and mergeable. Types that do
-not share the same kind are considered non-mergeable.
+across source schemas as semantically equivalent and mergeable.
+
+For the schema schema composition process to be able to merge types with the
+same name, the types must have the same kind. In this example we have two types
+called `User` which are both object types and are mergeable.
 
 ```graphql example
 type User {
@@ -51,11 +55,8 @@ type User {
 }
 ```
 
-```graphql example
-scalar DateTime
-
-scalar DateTime
-```
+However, if the second type would be a scalar type, the types would not be
+mergeable as they have different kinds.
 
 ```graphql counter-example
 type User {
@@ -68,14 +69,12 @@ type User {
 scalar User
 ```
 
-```graphql counter-example
-enum UserKind {
-  A
-  B
-  C
-}
+All types with the same name must have the same kind to be mergeable.
 
-scalar UserKind
+```graphql example
+scalar User
+
+scalar User
 ```
 
 ### Merge

--- a/spec/Section 4 -- Composition.md
+++ b/spec/Section 4 -- Composition.md
@@ -36,7 +36,7 @@ run in sequence to produce the composite execution schema.
 The GraphQL Composite Schemas specification considers types with the same name
 across source schemas as semantically equivalent and mergeable.
 
-For the schema schema composition process to be able to merge types with the
+For the schema composition process to be able to merge types with the
 same name, the types must have the same kind. In this example we have two types
 called `User` which are both object types and are mergeable.
 

--- a/spec/Section 4 -- Composition.md
+++ b/spec/Section 4 -- Composition.md
@@ -22,7 +22,7 @@ run in sequence to produce the composite execution schema.
 
 **Formal Specification**
 
-- Let {typesByName} be the set of all types across all subgraphs involved in the
+- Let {typesByName} be the set of all types across all source schemas involved in the
   schema composition by their given type name.
 - Given each pair of types {typeA} and {typeB} in {typesByName}
   - {typeA} and {typeB} must have the same kind

--- a/spec/Section 4 -- Composition.md
+++ b/spec/Section 4 -- Composition.md
@@ -18,7 +18,7 @@ run in sequence to produce the composite execution schema.
 
 **Error Code**
 
-TYPE_KIND_NOT_MERGABLE
+`TYPE_KIND_NOT_MERGABLE`
 
 **Formal Specification**
 

--- a/spec/Section 4 -- Composition.md
+++ b/spec/Section 4 -- Composition.md
@@ -55,7 +55,7 @@ type User {
 }
 ```
 
-However, if the second type would be a scalar type, the types would not be
+However, if the second type were a scalar type, the types would not be
 mergeable as they have different kinds.
 
 ```graphql counter-example

--- a/spec/Section 4 -- Composition.md
+++ b/spec/Section 4 -- Composition.md
@@ -14,6 +14,67 @@ run in sequence to produce the composite execution schema.
 
 ### Pre Merge Validation
 
+#### Semantical Equivalence of Types
+
+**Error Code**
+
+TYPE_KIND_NOT_MERGABLE
+
+**Formal Specification**
+
+- Let {typesByName} be the set of all types across all subgraphs involved in the
+  schema composition by their given type name.
+- Given each pair of types {typeA} and {typeB} in {typesByName}
+  - {typeA} and {typeB} must have the same kind
+
+**Explanatory Text**
+
+The GraphQL Composite Schemas specification considers types with the same name
+across source schemas as semantically equivalent and mergeable. Types that do not
+share the same kind are considered non-mergeable.
+
+```graphql example
+type User {
+  id: ID!
+  name: String!
+  displayName: String!
+  birthdate: String!
+}
+
+type User {
+  id: ID!
+  name: String!
+  reviews: [Review!]
+}
+```
+
+```graphql example
+scalar DateTime
+
+scalar DateTime
+```
+
+```graphql counter-example
+type User {
+  id: ID!
+  name: String!
+  displayName: String!
+  birthdate: String!
+}
+
+scalar User
+```
+
+```graphql counter-example
+enum UserKind {
+  A
+  B
+  C
+}
+
+scalar UserKind
+```
+
 ### Merge
 
 ### Post Merge Validation

--- a/spec/Section 4 -- Composition.md
+++ b/spec/Section 4 -- Composition.md
@@ -14,7 +14,7 @@ run in sequence to produce the composite execution schema.
 
 ### Pre Merge Validation
 
-#### Semantical Equivalence of Types
+#### Semantic Equivalence of Types
 
 **Error Code**
 

--- a/spec/Section 4 -- Composition.md
+++ b/spec/Section 4 -- Composition.md
@@ -30,8 +30,8 @@ TYPE_KIND_NOT_MERGABLE
 **Explanatory Text**
 
 The GraphQL Composite Schemas specification considers types with the same name
-across source schemas as semantically equivalent and mergeable. Types that do not
-share the same kind are considered non-mergeable.
+across source schemas as semantically equivalent and mergeable. Types that do
+not share the same kind are considered non-mergeable.
 
 ```graphql example
 type User {

--- a/spec/Section 4 -- Composition.md
+++ b/spec/Section 4 -- Composition.md
@@ -18,7 +18,7 @@ run in sequence to produce the composite execution schema.
 
 **Error Code**
 
-`TYPE_KIND_NOT_MERGABLE`
+`TYPE_KIND_NOT_MERGEABLE`
 
 **Formal Specification**
 

--- a/spec/Section 4 -- Composition.md
+++ b/spec/Section 4 -- Composition.md
@@ -22,10 +22,13 @@ run in sequence to produce the composite execution schema.
 
 **Formal Specification**
 
-- Let {typesByName} be the set of all types across all source schemas involved in the
-  schema composition by their given type name.
-- Given each pair of types {typeA} and {typeB} in {typesByName}
-  - {typeA} and {typeB} must have the same kind
+- Let {typesByName} be an empty unordered map of sets.
+- For each named type {type} across all source schemas:
+  - Let {name} be the name of {type}.
+  - Let {set} be the set in {typesByName} for {name}; if no such set exists, create it as an empty set.
+  - Add {type} to {set}.
+- For each {typesByName} as {name} and {types}:
+  - Each pair of types in {types} must have the same kind.
 
 **Explanatory Text**
 


### PR DESCRIPTION
The GraphQL Composite Schemas specification considers types with the same name
across source schemas as semantically equivalent and mergeable. Types that do not
share the same kind are considered non-mergeable.