### PR TITLE
Change `SameOutputTypeShape` to `SameTypeShape`

### DIFF
--- a/spec/Section 4 -- Composition.md
+++ b/spec/Section 4 -- Composition.md
@@ -149,7 +149,7 @@ FieldsAreMergeable(fields):
 - Given each pair of members {fieldA} and {fieldB} in {fields}:
   - Let {typeA} be the type of {fieldA}
   - Let {typeB} be the type of {fieldB}
-  - {SameOutputTypeShape(typeA, typeB)} must be true.
+  - {SameTypeShape(typeA, typeB)} must be true.
 
 **Explanatory Text**
 


### PR DESCRIPTION
1. Align with the naming [here](https://github.com/graphql/composite-schemas-spec/blob/main/spec/temp.md#composite-types).
2. I don't think that this is specific to output types.