### PR TITLE
Remove IsAccessible check on directive

### DIFF
--- a/spec/Section 4 -- Composition.md
+++ b/spec/Section 4 -- Composition.md
@@ -251,9 +251,9 @@ ERROR
 **Explanatory Text**
 
 This rule ensures that certain essential elements of a GraphQL schema,
-particularly built-in scalars, directive arguments, and introspection types, cannot be
-marked as `@inaccessible`. These types are fundamental to GraphQL. Making these
-elements inaccessible would break core GraphQL functionality.
+particularly built-in scalars, directive arguments, and introspection types,
+cannot be marked as `@inaccessible`. These types are fundamental to GraphQL.
+Making these elements inaccessible would break core GraphQL functionality.
 
 Here, the `String` type is not marked as `@inaccessible`, which adheres to the
 rule:

--- a/spec/Section 4 -- Composition.md
+++ b/spec/Section 4 -- Composition.md
@@ -245,14 +245,13 @@ ERROR
         - {IsAccessible(argument)} must be true.
 - For each {directive} in {directives}:
   - If {directive} is a built-in directive:
-    - {IsAccessible(directive)} must be true.
     - For each {argument} in {directive}:
       - {IsAccessible(argument)} must be true.
 
 **Explanatory Text**
 
 This rule ensures that certain essential elements of a GraphQL schema,
-particularly built-in scalars, directives and introspection types, cannot be
+particularly built-in scalars, directive arguments, and introspection types, cannot be
 marked as `@inaccessible`. These types are fundamental to GraphQL. Making these
 elements inaccessible would break core GraphQL functionality.
 


### PR DESCRIPTION
Removed this check, since GraphQL does not support directives (`@inaccessible`) on directives.

---

Closes #68