### PR TITLE
Adds more validation rules

### DIFF
--- a/spec/Section 4 -- Composition.md
+++ b/spec/Section 4 -- Composition.md
@@ -2074,6 +2074,67 @@ type Payment {
 }
 ```
 
+### Override from Self Error
+
+**Error Code**  
+`OVERRIDE_FROM_SELF_ERROR`
+
+**Severity**  
+ERROR
+
+**Formal Specification**
+
+- Let {schemas} be the set of all source schemas to be composed.
+- For each {schema} in {schemas}:
+  - Let {types} be the set of all composite types in {schema}.
+  - For each {type} in {types}:
+    - Let {fields} be the set of fields on {type}.
+    - For each {field} in {fields}:
+      - If {field} is annotated with `@override`:
+        - Let {from} be the value of the `from` argument of the `@override`
+          directive on {field}.
+        - {from} must **not** be the same as the name of {schema}:
+
+**Explanatory Text**
+
+When using `@override`, the `from` argument indicates the name of the source
+schema that originally owns the field. Overriding from the **same** schema
+creates a contradiction, as it implies both local and transferred ownership of
+the field within one schema. If the `from` value matches the local schema name,
+it triggers an `OVERRIDE_FROM_SELF_ERROR`.
+
+**Examples**
+
+In the following example, **Schema B** overrides the field `amount` from
+**Schema A**. The two schema names are different, so no error is raised.
+
+```graphql example
+# Source Schema A
+type Bill {
+  id: ID!
+  amount: Int
+}
+
+# Source Schema B
+type Bill {
+  id: ID!
+  amount: Int @override(from: "SchemaA")
+}
+```
+
+In the following counter-example, the local schema is also `"SchemaA"`, and the
+`from` argument is `"SchemaA"`. Overriding a field from the same schema is not
+allowed, causing an `OVERRIDE_FROM_SELF_ERROR`.
+
+```graphql counter-example
+# Source Schema A (named "SchemaA")
+type Bill {
+  id: ID!
+  amount: Int @override(from: "SchemaA")
+}
+```
+
+
 ### Merge
 
 ### Post Merge Validation

--- a/spec/Section 4 -- Composition.md
+++ b/spec/Section 4 -- Composition.md
@@ -2626,6 +2626,69 @@ type User {
 }
 ```
 
+### External on Interface
+
+**Error Code**  
+`EXTERNAL_ON_INTERFACE`
+
+**Severity**  
+ERROR
+
+**Formal Specification**
+
+- Let {schemas} be the set of all source schemas to be composed.
+- For each {schema} in {schemas}:
+  - Let {types} be the set of all composite types in {schema}.
+  - For each {type} in {types}:
+    - If {type} is an interface type:
+      - Let {fields} be the set of fields on {type}.
+      - For each {field} in {fields}:
+        - {field} must **not** be annotated with `@external`
+
+**Explanatory Text**
+
+The `@external` directive indicates that a field is **defined** and **resolved**
+elsewhere, not in the current schema. In the case of an **interface** type,
+fields are **abstract** - they do not have direct resolutions at the interface
+level. Instead, each implementing object type provides the concrete field
+implementations. Marking an **interface** field with `@external` is therefore
+nonsensical, as there is no actual field resolution in the interface itself to
+“borrow” from another schema. Such usage raises an `EXTERNAL_ON_INTERFACE`
+error.
+
+**Examples**
+
+Here, the interface `Node` merely describes the field `id`. Object types `User`
+and `Product` implement and resolve `id`. No `@external` usage occurs on the
+interface itself, so no error is triggered.
+
+```graphql example
+interface Node {
+  id: ID!
+}
+
+type User implements Node {
+  id: ID!
+  name: String
+}
+
+type Product implements Node {
+  id: ID!
+  price: Int
+}
+```
+
+Since `id` is declared on an **interface** and marked with `@external`, the
+composition fails with `EXTERNAL_ON_INTERFACE`. An interface does not own the
+concrete field resolution, so it is invalid to mark any of its fields as
+external.
+
+```graphql counter-example
+interface Node {
+  id: ID! @external
+}
+```
+
 
 ### Merge
 

--- a/spec/Section 4 -- Composition.md
+++ b/spec/Section 4 -- Composition.md
@@ -3245,4 +3245,62 @@ type Subscription {
 }
 ```
 
+### Invalid Shareable Usage
+
+**Error Code**
+
+`INVALID_SHAREABLE_USAGE`
+
+**Severity**
+
+ERROR
+
+**Formal Specification**
+
+- Let {schema} be one of the composed schemas.
+- Let {types} be the set of types defined in {schema}.
+- For each {type} in {types}:
+  - If {type} is an interface type:
+    - For each field definition {field} in {type}:
+      - If {field} is annotated with `@shareable`, produce an
+        `INVALID_SHAREABLE_USAGE` error.
+
+**Explanatory Text**
+
+The `@shareable` directive is intended to indicate that a field on an **object
+type** can be resolved by multiple schemas without conflict. As a result, it is
+only valid to use `@shareable` on fields **of object types** (or on the entire
+object type itself).
+
+Applying `@shareable` to interface fields is disallowed and violates the valid
+usage of the directive. This rule prevents schema composition errors and data
+conflicts by ensuring that `@shareable` is used only in contexts where shared
+field resolution is meaningful and unambiguous.
+
+**Examples**
+
+In this example, the field `orderStatus` on the `Order` object type is marked
+with `@shareable`, which is allowed. It signals that this field can be served
+from multiple schemas without creating a conflict.
+
+```graphql example
+type Order {
+  id: ID!
+  orderStatus: String @shareable
+  total: Float
+}
+```
+
+In this example, the `InventoryItem` interface has a field `sku` marked with
+`@shareable`, which is invalid usage. Marking an interface field as shareable
+leads to an `INVALID_SHAREABLE_USAGE` error.
+
+```graphql counter-example
+interface InventoryItem {
+  sku: ID! @shareable
+  name: String
+}
+```
+
+
 ## Validate Satisfiability

--- a/spec/Section 4 -- Composition.md
+++ b/spec/Section 4 -- Composition.md
@@ -2563,6 +2563,69 @@ type ProductDetails {
 }
 ```
 
+### Provides on Non-Composite Field
+
+**Error Code**  
+`PROVIDES_ON_NON_COMPOSITE_FIELD`
+
+**Severity**  
+ERROR
+
+**Formal Specification**
+
+- Let {schemas} be the set of all source schemas to be composed.
+- For each {schema} in {schemas}:
+  - Let {types} be the set of all object and interface types in {schema}.
+  - For each {type} in {types}:
+    - Let {fields} be the set of fields on {type}.
+    - For each {field} in {fields}:
+      - If {field} is annotated with `@provides`:
+        - Let {fieldType} be the base return type of {field} (i.e., unwrapped of
+          any `[ ]` or `!`).
+        - {fieldType} must be a interface or object type.
+
+**Explanatory Text**
+
+The `@provides` directive allows a field to “provide” additional nested fields
+on the composite type it returns. If a field’s base type is not an object or
+interface type (e.g., `String`, `Int`, `Boolean`, `Enum`, `Union`, or an `Input`
+type), it cannot hold nested fields for `@provides` to select. Consequently,
+attaching `@provides` to such a field is invalid and raises a
+`PROVIDES_ON_NON_OBJECT_FIELD` error.
+
+**Examples**
+
+Here, `profile` has an **object** base type `Profile`. The `@provides` directive
+can validly specify sub-fields like `settings { theme }`.
+
+```graphql example
+type Profile {
+  email: String
+  settings: Settings
+}
+
+type Settings {
+  notificationsEnabled: Boolean
+  theme: String
+}
+
+type User {
+  id: ID!
+  profile: Profile @provides(fields: "settings { theme }")
+}
+```
+
+In this counter-example, `email` has a scalar base type (`String`). Because
+scalars do not expose sub-fields, attaching `@provides` to `email` triggers a
+`PROVIDES_ON_NON_OBJECT_FIELD` error.
+
+```graphql counter-example
+type User {
+  id: ID!
+  email: String @provides(fields: "length")
+}
+```
+
 
 ### Merge
 

--- a/spec/Section 4 -- Composition.md
+++ b/spec/Section 4 -- Composition.md
@@ -785,6 +785,71 @@ type Mutation {
 }
 ```
 
+### Root Query Used
+
+**Error Code**
+
+`ROOT_QUERY_USED`
+
+**Severity**
+
+ERROR
+
+**Formal Specification**
+
+- Let {schemas} be the set of all source schemas.
+- For each {schema} in {schemas}:
+  - Let {rootQuery} be the root mutation type defined in {schema}, if it exists.
+  - Let {namedQueryType} be the type with the name `Query` in {schema}, if it
+    exists.
+  - If {rootQuery} is defined:
+    - {rootQuery} must be named `Query`.
+  - Otherwise, {namedQueryType} must not be defined.
+
+**Explanatory Text**
+
+This rule enforces that the root query type in any source schema must be named
+`Query`. Defining a root query type with a name other than `Query` or using a
+differently named type alongside a type explicitly named `Query` creates
+inconsistencies in schema design and violates the composite schema
+specification.
+
+**Examples**
+
+Valid example:
+
+```graphql example
+schema {
+  query: Query
+}
+
+type Query {
+  product(id: ID!): Product
+}
+
+type Product {
+  id: ID!
+  name: String
+}
+```
+
+The following counter-example violates the rule because `RootQuery` is used as
+the root query type, but a type named `Query` is also defined.
+
+```graphql counter-example
+schema {
+  query: RootQuery
+}
+
+type RootQuery {
+  product(id: ID!): Product
+}
+
+type Query {
+  deprecatedField: String
+}
+```
+
 
 ### Merge
 

--- a/spec/Section 4 -- Composition.md
+++ b/spec/Section 4 -- Composition.md
@@ -1872,6 +1872,59 @@ extend input User {
 }
 ```
 
+### Provides Invalid Syntax
+
+**Error Code**  
+`PROVIDES_INVALID_SYNTAX`
+
+**Severity**  
+ERROR
+
+**Formal Specification**
+
+- Let {schemas} be the set of all source schemas.
+- For each {schema} in {schemas}
+  - Let {fieldsWithProvides} be the set of all fields annotated with the
+    `@provides` directive in {schema}.
+  - For each {field} in {fieldsWithProvides}:
+    - Let {fieldsArg} be the string value of the `fields` argument of the
+      `@provides` directive on {field}.
+    - {fieldsArg} must be a valid selection set string
+
+**Explanatory Text**
+
+The `@provides` directive’s `fields` argument must be a syntactically valid
+selection set string, as if you were selecting fields in a GraphQL query. If the
+selection set is malformed (e.g., missing braces, unbalanced quotes, or invalid
+tokens), the schema composition fails with a `PROVIDES_INVALID_SYNTAX` error.
+
+**Examples**
+
+Here, the `@provides` directive’s `fields` argument is a valid selection set:
+
+```graphql example
+type User @key(fields: "id") {
+  id: ID!
+  address: Address @provides(fields: "street city")
+}
+
+type Address {
+  street: String
+  city: String
+}
+```
+
+In this counter-example, the `fields` argument is missing a closing brace. It
+cannot be parsed as a valid GraphQL selection set, triggering a
+`PROVIDES_INVALID_SYNTAX` error.
+
+```graphql counter-example
+type User @key(fields: "id") {
+  id: ID!
+  address: Address @provides(fields: "{ street city ")
+}
+```
+
 
 ### Merge
 

--- a/spec/Section 4 -- Composition.md
+++ b/spec/Section 4 -- Composition.md
@@ -1262,6 +1262,81 @@ type Product @key(fields: "id") {
 }
 ```
 
+### Provides Directive in Fields Argument
+
+**Error Code**
+
+`PROVIDES_DIRECTIVE_IN_FIELDS_ARG`
+
+**Severity**
+
+ERROR
+
+**Formal Specification**
+
+- Let {schema} be the set of all source schemas.
+  - Let {fieldsWithProvides} be the set of all fields annotated with the
+    `@provides` directive in {schema}.
+  - For each {field} in {fieldsWithProvides}:
+    - Let {fields} be the selected fields of the `fields` argument of the
+      `@provides` directive on {field}.
+    - For each {selection} in {fields}:
+      - {HasProvidesDirective(selection)} must be false
+
+HasProvidesDirective(selection):
+
+- If {selection} has a directive application:
+  - return true
+- If {selection} has a selection set:
+  - Let {subSelections} be the selections in {selection}
+  - For each {subSelection} in {subSelections}:
+    - If {HasProvidesDirective(subSelection)} is true
+      - return true
+
+**Explanatory Text**
+
+The `@provides` directive is used to specify the set of fields on an object type
+that a resolver provides for the parent type. The `fields` argument must consist
+of a valid GraphQL selection set without any directive applications, as
+directives within the `fields` argument are not supported.
+
+**Examples**
+
+In this example, the `fields` argument of the `@provides` directive does not
+have any directive applications, satisfying the rule.
+
+```graphql example
+type User @key(fields: "id name") {
+  id: ID!
+  name: String
+  profile: Profile @provides(fields: "name")
+}
+
+type Profile {
+  id: ID!
+  name: String
+}
+```
+
+In this counter-example, the `fields` argument of the `@provides` directive has
+a directive application `@lowercase`, which is not allowed.
+
+```graphql counter-example
+directive @lowercase on FIELD_DEFINITION
+
+type User @key(fields: "id name") {
+  id: ID!
+  name: String
+  profile: Profile @provides(fields: "name @lowercase")
+}
+
+type Profile {
+  id: ID!
+  name: String
+}
+```
+
+
 ### Merge
 
 ### Post Merge Validation

--- a/spec/Section 4 -- Composition.md
+++ b/spec/Section 4 -- Composition.md
@@ -1684,6 +1684,71 @@ type Profile {
 }
 ```
 
+### Require Invalid Syntax
+
+**Error Code**
+
+`REQUIRE_INVALID_SYNTAX`
+
+**Severity**
+
+ERROR
+
+**Formal Specification**
+
+- Let {schemas} be the set of all source schemas.
+- For each {schema} in {schemas}
+  - Let {compositeTypes} be the set of all composite types in {schema}.
+  - For each {composite} in {compositeTypes}:
+    - Let {fields} be the set of fields on {composite}.
+    - Let {arguments} be the set of all arguments on {fields}.
+    - For each {argument} in {arguments}:
+      - If {argument} is **not** annotated with `@require`:
+        - Continue
+      - Let {fieldsArg} be the string value of the `fields` argument of the
+        `@require` directive on {argument}.
+      - {fieldsArg} must be be parsable as a valid selection map
+
+**Explanatory Text**
+
+The `@require` directive’s `fields` argument must be syntactically valid
+GraphQL. If the selection map string is malformed (e.g., missing closing braces,
+unbalanced quotes, invalid tokens), then the schema cannot be composed
+correctly. In such cases, the error `REQUIRE_INVALID_SYNTAX` is raised.
+
+**Examples**
+
+In the following example, the `@require` directive’s `fields` argument is a
+valid selection map and satisfies the rule.
+
+```graphql example
+type User @key(fields: "id") {
+  id: ID!
+  profile(name: String! @require(fields: "name")): Profile
+}
+
+type Profile {
+  id: ID!
+  name: String
+}
+```
+
+In the following counter-example, the `@require` directive’s `fields` argument
+has invalid syntax because it is missing a closing brace.
+
+This violates the rule and triggers a `REQUIRE_INVALID_FIELDS` error.
+
+```graphql counter-example
+type Book {
+  id: ID!
+  title(lang: String! @require(fields: "author { name ")): String
+}
+
+type Author {
+  name: String
+}
+```
+
 ### Merge
 
 ### Post Merge Validation

--- a/spec/Section 4 -- Composition.md
+++ b/spec/Section 4 -- Composition.md
@@ -719,6 +719,73 @@ type Product {
 }
 ```
 
+### Root Mutation Used
+
+**Error Code**
+
+`ROOT_MUTATION_USED`
+
+**Severity**
+
+ERROR
+
+**Formal Specification**
+
+- Let {schemas} be the set of all source schemas.
+- For each {schema} in {schemas}:
+  - Let {rootMutation} be the root mutation type defined in {schema}, if it
+    exists.
+  - Let {namedMutationType} be the type with the name `Mutation` in {schema}, if
+    it exists.
+  - If {rootMutation} is defined:
+    - {rootMutation} must be named `Mutation`.
+  - Otherwise, {namedMutationType} must not be defined.
+
+**Explanatory Text**
+
+This rule enforces that, for any source schema, if a root mutation type is
+defined, it must be named `Mutation`. Defining a root mutation type with a name
+other than `Mutation` or using a differently named type alongside a type
+explicitly named `Mutation` creates inconsistencies in schema design and
+violates the composite schema specification.
+
+**Examples**
+
+Valid example:
+
+```graphql example
+schema {
+  mutation: Mutation
+}
+
+type Mutation {
+  createProduct(name: String): Product
+}
+
+type Product {
+  id: ID!
+  name: String
+}
+```
+
+The following counter-example violates the rule because `RootMutation` is used
+as the root mutation type, but a type named `Mutation` is also defined.
+
+```graphql counter-example
+schema {
+  mutation: RootMutation
+}
+
+type RootMutation {
+  createProduct(name: String): Product
+}
+
+type Mutation {
+  deprecatedField: String
+}
+```
+
+
 ### Merge
 
 ### Post Merge Validation

--- a/spec/Section 4 -- Composition.md
+++ b/spec/Section 4 -- Composition.md
@@ -1549,7 +1549,74 @@ type Book {
 }
 ```
 
+### Require Directive in Fields Argument
 
+**Error Code**
+
+`REQUIRE_DIRECTIVE_IN_FIELDS_ARG`
+
+**Severity**
+
+ERROR
+
+**Formal Specification**
+
+- Let {schemas} be the set of all source schemas.
+- For each {schema} in {schemas}:
+  - Let {compositeTypes} be the set of all composite types in {schema}.
+  - For each {composite} in {compositeTypes}:
+    - Let {fields} be the set of fields on {composite}
+    - Let {arguments} be the set of all arguments on {fields}
+    - For each {argument} in {arguments}:
+      - If {argument} is **not** marked with `@require`:
+        - Continue
+      - Let {fieldsArg} be the value of the `fields` argument of the `@require`
+        directive on {argument}.
+      - If {fieldsArg} contains a directive application:
+        - Produce a `REQUIRE_DIRECTIVE_IN_FIELDS_ARG` error.
+
+**Explanatory Text**
+
+The `@require` directive is used to specify fields on the same type that an
+argument depends on in order to resolve the annotated field.  
+When using `@require(fields: "…")`, the `fields` argument must be a valid
+selection set string **without** any additional directive applications.  
+Applying a directive (e.g., `@lowercase`) inside this selection set is not
+supported and triggers the `REQUIRE_DIRECTIVE_IN_FIELDS_ARG` error.
+
+**Examples**
+
+In this valid usage, the `@require` directive’s `fields` argument references
+`name` without any directive applications, avoiding the error.
+
+```graphql example
+type User @key(fields: "id name") {
+  id: ID!
+  profile(name: String! @require(fields: "name")): Profile
+}
+
+type Profile {
+  id: ID!
+  name: String
+}
+```
+
+Because the `@require` selection (`name @lowercase`) includes a directive
+application (`@lowercase`), this violates the rule and triggers a
+`REQUIRE_DIRECTIVE_IN_FIELDS_ARG` error.
+
+```graphql counter-example
+type User @key(fields: "id name") {
+  id: ID!
+  name: String
+  profile(name: String! @require(fields: "name @lowercase")): Profile
+}
+
+type Profile {
+  id: ID!
+  name: String
+}
+```
 
 ### Merge
 

--- a/spec/Section 4 -- Composition.md
+++ b/spec/Section 4 -- Composition.md
@@ -917,6 +917,91 @@ type Subscription {
 }
 ```
 
+### Key Fields Select Invalid Type
+
+**Error Code**
+
+`KEY_FIELDS_SELECT_INVALID_TYPE`
+
+**Severity**
+
+ERROR
+
+**Formal Specification**
+
+- Let {schema} be the set of all source schemas.
+  - Let {types} be the set of all object or interface types that are annotated
+    with the `@key` directive in {schema}.
+  - For each {type} in {types}:
+    - Let {keyDirectives} be the set of all `@key` directives on {type}.
+    - For each {keyDirective} in {keyDirectives}
+      - Let {keyFields} be the set of all fields (including nested) referenced
+        by the `fields` argument of {keyDirective}.
+      - For each {field} in {keyFields}:
+        - Let {fieldType} be the type of {field}.
+        - {fieldType} must not be a `List`, `Interface`, or `Union` type.
+
+**Explanatory Text**
+
+The `@key` directive is used to define the set of fields that uniquely identify
+an entity. These fields must reference scalars or object types to ensure a valid
+and consistent representation of the entity across schemas. Fields of types
+`List`, `Interface`, or `Union` cannot be part of a `@key` because they do not
+have a well-defined unique value.
+
+**Examples**
+
+In this valid example, the `Product` type has a valid `@key` directive
+referencing the scalar field `sku`.
+
+```graphql example
+type Product @key(fields: "sku") {
+  sku: String!
+  name: String
+}
+```
+
+In the following counter-example, the `Product` type has an invalid `@key`
+directive referencing a field (`featuredItem`) whose type is an interface,
+violating the rule.
+
+```graphql counter-example
+type Product @key(fields: "featuredItem { id }") {
+  featuredItem: Node!
+  sku: String!
+}
+
+interface Node {
+  id: ID!
+}
+```
+
+In this counter example, the `@key` directive references a field (`tags`) of
+type `List`, which is also not allowed.
+
+```graphql counter-example
+type Product @key(fields: "tags") {
+  tags: [String!]!
+  sku: String!
+}
+```
+
+In this counter example, the `@key` directive references a field
+(`relatedItems`) of type `Union`, which violates the rule.
+
+```graphql counter-example
+type Product @key(fields: "relatedItems") {
+  relatedItems: Related!
+  sku: String!
+}
+
+union Related = Product | Service
+
+type Service {
+  id: ID!
+}
+```
+
 ### Merge
 
 ### Post Merge Validation

--- a/spec/Section 4 -- Composition.md
+++ b/spec/Section 4 -- Composition.md
@@ -1938,7 +1938,7 @@ ERROR
 - Let {schemas} be the set of all source schemas to be composed.
 - For Each {schema} in {schemas}
   - {schema} must be a syntactically valid
-  - {schama} must be a semantically valid GraphQL schema according to the
+  - {schema} must be a semantically valid GraphQL schema according to the
     [GraphQL specification](https://spec.graphql.org/).
 
 **Explanatory Text**
@@ -2222,7 +2222,7 @@ ERROR
       - Continue
     - Let {firstOverride} be the first directive in {overrides}.
     - Let {from} be the value of the `from` argument on {firstOverride}.
-    - Let {sourceSchema} be the schema definining {firstOverride}.
+    - Let {sourceSchema} be the schema defining {firstOverride}.
     - Let {visited} be an empty set.
     - Add {sourceSchema} to {visited}.
     - While {from} is not null:
@@ -2376,8 +2376,7 @@ local ownership or resolution responsibility, such as:
 
 - **`@override`**: Transfers ownership of the field’s definition from one schema
   to another, which is incompatible with an already-external field definition.
-  Yet this behaviour is covered by the
-  `OVERRIDE_COLLISION_WITH_ANOTHER_DIRECTIVE` rule.
+  Yet this is covered by the `OVERRIDE_COLLISION_WITH_ANOTHER_DIRECTIVE` rule.
 
 Any combination of `@external` with either `@provides` or `@require` on the same
 field results in inconsistent semantics. In such scenarios, an
@@ -2689,7 +2688,6 @@ interface Node {
 }
 ```
 
-
 ### Merge
 
 ### Post Merge Validation
@@ -2990,7 +2988,7 @@ type User implements Node {
 
 **Error Code**
 
-`INTERFACE_FIELD_NO_IMPLEM`
+`INTERFACE_FIELD_NO_IMPLEMENTATION`
 
 **Severity**
 
@@ -3007,7 +3005,7 @@ ERROR
       visible in the merged schema.
     - For each {field} in {interfaceFields}:
       - If {field} is not present on {objectType}:
-        - Produce an `INTERFACE_FIELD_NO_IMPLEM` error.
+        - Produce an `INTERFACE_FIELD_NO_IMPLEMENTATION` error.
 
 **Explanatory Text**
 
@@ -3060,12 +3058,12 @@ type GuestUser implements User {
 
 In this counter-example, the `User` interface is defined with three fields, but
 the `GuestUser` type omits one of them (`email`), causing an
-`INTERFACE_FIELD_NO_IMPLEM` error.
+`INTERFACE_FIELD_NO_IMPLEMENTATION` error.
 
 Although `GuestUser` implements `User`, it does not provide the `email` field.
 Since the merged schema sees that the interface `User` has `email` but
 `GuestUser` does not provide it, the schema composition fails with the
-`INTERFACE_FIELD_NO_IMPLEM` error.
+`INTERFACE_FIELD_NO_IMPLEMENTATION` error.
 
 ```graphql counter-example
 # Schema A
@@ -3162,7 +3160,7 @@ type User @key(fields: "id") {
 }
 ```
 
-In the following example, `User.fullName` is overriden in one schema and
+In the following example, `User.fullName` is overridden in one schema and
 therefore the field can be define in multiple schemas without being marked as
 `@shareable`.
 

--- a/spec/Section 4 -- Composition.md
+++ b/spec/Section 4 -- Composition.md
@@ -1485,6 +1485,70 @@ type Order {
 }
 ```
 
+### Query Root Type Inaccessible
+
+**Error Code**
+
+`QUERY_ROOT_TYPE_INACCESSIBLE`
+
+**Severity**
+
+ERROR
+
+**Formal Specification**
+
+- Let {schemas} be the set of all source schemas.
+- For each {schema} in {schemas}:
+  - Let {queryType} be the query operation type defined in {schema}.
+  - If {queryType} is annotated with `@inaccessible`:
+    - Produce a `QUERY_ROOT_TYPE_INACCESSIBLE` error.
+
+**Explanatory Text**
+
+Every source schema that contributes to the final composite schema must expose a
+public (accessible) root query type. Marking the root query type as
+`@inaccessible` makes it invisible to the gateway, defeating its purpose as the
+primary entry point for queries and lookups.
+
+**Examples**
+
+In this example, no `@inaccessible` annotation is applied to the query root, so
+the rule is satisfied.
+
+```graphql example
+extend schema {
+  query: Query
+}
+
+type Query {
+  allBooks: [Book]
+}
+
+type Book {
+  id: ID!
+  title: String
+}
+```
+
+Since the schema marks the query root type as `@inaccessible`, the rule is
+violated. `QUERY_ROOT_TYPE_INACCESSIBLE` is raised because a schema’s root query
+type cannot be hidden from consumers.
+
+```graphql counter-example
+extend schema {
+  query: Query
+}
+
+type Query @inaccessible {
+  allBooks: [Book]
+}
+
+type Book {
+  id: ID!
+  title: String
+}
+```
+
 
 
 ### Merge

--- a/spec/Section 4 -- Composition.md
+++ b/spec/Section 4 -- Composition.md
@@ -1618,6 +1618,72 @@ type Profile {
 }
 ```
 
+### Require Invalid Fields Type
+
+**Error Code**
+
+`REQUIRE_INVALID_FIELDS_TYPE`
+
+**Severity**
+
+ERROR
+
+**Formal Specification**
+
+- Let {schemas} be the set of all source schemas.
+- For each {schema} in {schemas}:
+  - Let {compositeTypes} be the set of all composite types in {schema}.
+  - For each {composite} in {compositeTypes}:
+    - Let {fields} be the set of fields on {composite}.
+    - Let {arguments} be the set of all arguments on {fields}.
+    - For each {argument} in {arguments}:
+      - If {argument} is **not** annotated with `@require`:
+        - Continue
+      - Let {fieldsArg} be the value of the `fields` argument of the `@require`
+        directive on {argument}.
+      - If {fieldsArg} is **not** a string:
+        - Produce a `REQUIRE_INVALID_FIELDS_TYPE` error.
+
+**Explanatory Text**
+
+When using the `@require` directive, the `fields` argument must always be a
+string that defines a (potentially nested) selection set of fields from the same
+type. If the `fields` argument is provided as a type other than a string (such
+as an integer, boolean, or enum), the directive usage is invalid and will cause
+schema composition to fail.
+
+**Examples**
+
+In the following example, the `@require` directive’s `fields` argument is a
+valid string and satisfies the rule.
+
+```graphql example
+type User @key(fields: "id") {
+  id: ID!
+  profile(name: String! @require(fields: "name")): Profile
+}
+
+type Profile {
+  id: ID!
+  name: String
+}
+```
+
+Since `fields` is set to `123` (an integer) instead of a string, this violates
+the rule and triggers a `REQUIRE_INVALID_FIELDS_TYPE` error.
+
+```graphql counter-example
+type User @key(fields: "id") {
+  id: ID!
+  profile(name: String! @require(fields: 123)): Profile
+}
+
+type Profile {
+  id: ID!
+  name: String
+}
+```
+
 ### Merge
 
 ### Post Merge Validation

--- a/spec/Section 4 -- Composition.md
+++ b/spec/Section 4 -- Composition.md
@@ -2495,6 +2495,74 @@ type User @key(fields: true) {
 }
 ```
 
+### Provides Invalid Fields Type
+
+**Error Code**  
+`PROVIDES_INVALID_FIELDS_TYPE`
+
+**Severity**  
+ERROR
+
+**Formal Specification**
+
+- Let {schemas} be the set of all source schemas to be composed.
+- For each {schema} in {schemas}:
+  - Let {types} be the set of all composite types in {schema}.
+  - For each {type} in {types}:
+    - Let {fields} be the set of fields on {type}.
+    - For each {field} in {fields}:
+      - If {field} is annotated with `@provides`:
+        - Let {fieldsArg} be the value of the `fields` argument on the
+          `@provides` directive.
+        - {fieldsArg} must be a string.
+
+**Explanatory Text**
+
+The `@provides` directive indicates that a field is **providing** one or more
+additional fields on the returned (child) type. The `fields` argument accepts a
+**string** representing a GraphQL selection set (for example, `"title author"`).
+If the `fields` argument is given as a non-string type (e.g., `Boolean`, `Int`,
+`Array`), the schema fails to compose because it cannot interpret a valid
+selection set.
+
+**Examples**
+
+In this valid example, the `@provides` directive on `details` uses the string
+`"features specifications"` to specify that both fields are provided in the
+child type `ProductDetails`.
+
+```graphql example
+type Product {
+  id: ID!
+  details: ProductDetails @provides(fields: "features specifications")
+}
+
+type ProductDetails {
+  features: [String]
+  specifications: String
+}
+
+type Query {
+  products: [Product]
+}
+```
+
+Here, the `@provides` directive includes a numeric value (`123`) instead of a
+string in its `fields` argument. This invalid usage raises a
+`PROVIDES_INVALID_FIELDS_TYPE` error.
+
+```graphql counter-example
+type Product {
+  id: ID!
+  details: ProductDetails @provides(fields: 123)
+}
+
+type ProductDetails {
+  features: [String]
+  specifications: String
+}
+```
+
 
 ### Merge
 

--- a/spec/Section 4 -- Composition.md
+++ b/spec/Section 4 -- Composition.md
@@ -1002,6 +1002,75 @@ type Service {
 }
 ```
 
+### Key Directive in Fields Argument
+
+**Error Code**
+
+`KEY_DIRECTIVE_IN_FIELDS_ARG`
+
+**Severity**
+
+ERROR
+
+**Formal Specification**
+
+- Let {schema} be the set of all source schemas.
+  - Let {types} be the set of all object and interface types in {schema}.
+  - For each {type} in {types}:
+    - Let {keyDirectives} be the set of all `@key` directives on {type}.
+    - For each {keyDirective} in {keyDirectives}:
+      - Let {fields} be the string value of the `fields` argument of
+        {keyDirective}.
+      - {fields} must not contain a directive application.
+
+**Explanatory Text**
+
+The `@key` directive specifies the set of fields used to uniquely identify an
+entity. The `fields` argument must consist of a valid GraphQL selection set that
+does not include any directive applications. Directives in the `fields` argument
+are not supported.
+
+**Examples**
+
+In this example, the `fields` argument of the `@key` directive does not include
+any directive applications, satisfying the rule.
+
+```graphql example
+type User @key(fields: "id name") {
+  id: ID!
+  name: String
+}
+```
+
+In this counter-example, the `fields` argument of the `@key` directive includes
+a directive application `@lowercase`, which is not allowed.
+
+```graphql counter-example
+directive @lowercase on FIELD_DEFINITION
+
+type User @key(fields: "id name @lowercase") {
+  id: ID!
+  name: String
+}
+```
+
+In this example, the `fields` argument includes a directive application
+`@lowercase` nested inside the selection set, which is also invalid.
+
+```graphql counter-example
+directive @lowercase on FIELD_DEFINITION
+
+type User @key(fields: "id name { firstName @lowercase }") {
+  id: ID!
+  name: FullName
+}
+
+type FullName {
+  firstName: String
+  lastName: String
+}
+```
+
 ### Merge
 
 ### Post Merge Validation

--- a/spec/Section 4 -- Composition.md
+++ b/spec/Section 4 -- Composition.md
@@ -743,7 +743,7 @@ type Product {
 }
 ```
 
-### Root Mutation Used
+#### Root Mutation Used
 
 **Error Code**
 
@@ -809,7 +809,7 @@ type Mutation {
 }
 ```
 
-### Root Query Used
+#### Root Query Used
 
 **Error Code**
 
@@ -874,7 +874,7 @@ type Query {
 }
 ```
 
-### Root Subscription Used
+#### Root Subscription Used
 
 **Error Code**
 
@@ -941,7 +941,7 @@ type Subscription {
 }
 ```
 
-### Key Fields Select Invalid Type
+#### Key Fields Select Invalid Type
 
 **Error Code**
 
@@ -1026,7 +1026,7 @@ type Service {
 }
 ```
 
-### Key Directive in Fields Argument
+#### Key Directive in Fields Argument
 
 **Error Code**
 
@@ -1095,7 +1095,7 @@ type FullName {
 }
 ```
 
-### Key Fields Has Arguments
+#### Key Fields Has Arguments
 
 **Error Code**
 
@@ -1157,7 +1157,7 @@ type User @key(fields: "id tags") {
 }
 ```
 
-### Key Invalid Syntax
+#### Key Invalid Syntax
 
 **Error Code**  
 `KEY_INVALID_SYNTAX`
@@ -1217,7 +1217,7 @@ interface Node {
 }
 ```
 
-### Key Invalid Fields
+#### Key Invalid Fields
 
 **Error Code**
 
@@ -1286,7 +1286,7 @@ type Product @key(fields: "id") {
 }
 ```
 
-### Provides Directive in Fields Argument
+#### Provides Directive in Fields Argument
 
 **Error Code**
 
@@ -1360,7 +1360,7 @@ type Profile {
 }
 ```
 
-### Provides Fields Has Arguments
+#### Provides Fields Has Arguments
 
 **Error Code**
 
@@ -1436,7 +1436,7 @@ type Article @key(fields: "id") {
 }
 ```
 
-### Provides Fields Missing External
+#### Provides Fields Missing External
 
 **Error Code**
 
@@ -1509,7 +1509,7 @@ type Order {
 }
 ```
 
-### Query Root Type Inaccessible
+#### Query Root Type Inaccessible
 
 **Error Code**
 
@@ -1573,7 +1573,7 @@ type Book {
 }
 ```
 
-### Require Directive in Fields Argument
+#### Require Directive in Fields Argument
 
 **Error Code**
 
@@ -1642,7 +1642,7 @@ type Profile {
 }
 ```
 
-### Require Invalid Fields Type
+#### Require Invalid Fields Type
 
 **Error Code**
 
@@ -1708,7 +1708,7 @@ type Profile {
 }
 ```
 
-### Require Invalid Syntax
+#### Require Invalid Syntax
 
 **Error Code**
 
@@ -1773,7 +1773,7 @@ type Author {
 }
 ```
 
-### Type Definition Invalid
+#### Type Definition Invalid
 
 **Error Code**
 
@@ -1819,7 +1819,7 @@ input FieldSelectionMap {
 }
 ```
 
-### Type Kind Mismatch
+#### Type Kind Mismatch
 
 **Error Code**  
 `TYPE_KIND_MISMATCH`
@@ -1896,7 +1896,7 @@ extend input User {
 }
 ```
 
-### Provides Invalid Syntax
+#### Provides Invalid Syntax
 
 **Error Code**  
 `PROVIDES_INVALID_SYNTAX`
@@ -1949,7 +1949,7 @@ type User @key(fields: "id") {
 }
 ```
 
-### Invalid GraphQL
+#### Invalid GraphQL
 
 **Error Code**  
 `INVALID_GRAPHQL`
@@ -2028,7 +2028,7 @@ type Product {
 }
 ```
 
-### Override Collision with Another Directive
+#### Override Collision with Another Directive
 
 **Error Code**  
 `OVERRIDE_COLLISION_WITH_ANOTHER_DIRECTIVE`
@@ -2098,7 +2098,7 @@ type Payment {
 }
 ```
 
-### Override from Self Error
+#### Override from Self Error
 
 **Error Code**  
 `OVERRIDE_FROM_SELF_ERROR`
@@ -2158,7 +2158,7 @@ type Bill {
 }
 ```
 
-### Override on Interface
+#### Override on Interface
 
 **Error Code**  
 `OVERRIDE_ON_INTERFACE`
@@ -2221,7 +2221,7 @@ interface Bill {
 }
 ```
 
-### Override Source Has Override
+#### Override Source Has Override
 
 **Error Code**  
 `OVERRIDE_SOURCE_HAS_OVERRIDE`
@@ -2362,7 +2362,7 @@ type Bill {
 }
 ```
 
-### External Collision with Another Directive
+#### External Collision with Another Directive
 
 **Error Code**  
 `EXTERNAL_COLLISION_WITH_ANOTHER_DIRECTIVE`
@@ -2463,7 +2463,7 @@ type Book {
 }
 ```
 
-### Key Invalid Fields Type
+#### Key Invalid Fields Type
 
 **Error Code**  
 `KEY_INVALID_FIELDS_TYPE`
@@ -2518,7 +2518,7 @@ type User @key(fields: true) {
 }
 ```
 
-### Provides Invalid Fields Type
+#### Provides Invalid Fields Type
 
 **Error Code**  
 `PROVIDES_INVALID_FIELDS_TYPE`
@@ -2586,7 +2586,7 @@ type ProductDetails {
 }
 ```
 
-### Provides on Non-Composite Field
+#### Provides on Non-Composite Field
 
 **Error Code**  
 `PROVIDES_ON_NON_COMPOSITE_FIELD`
@@ -2649,7 +2649,7 @@ type User {
 }
 ```
 
-### External on Interface
+#### External on Interface
 
 **Error Code**  
 `EXTERNAL_ON_INTERFACE`
@@ -2808,7 +2808,7 @@ type ObjectType1 {
 }
 ```
 
-### No Queries
+#### No Queries
 
 **Error Code**
 
@@ -2931,7 +2931,7 @@ type AdminStats {
 }
 ```
 
-### Implemented by Inaccessible
+#### Implemented by Inaccessible
 
 **Error Code**
 
@@ -3020,7 +3020,7 @@ type User implements Node {
 }
 ```
 
-### Interface Field No Implementation
+#### Interface Field No Implementation
 
 **Error Code**
 
@@ -3129,7 +3129,7 @@ type GuestUser implements User {
 }
 ```
 
-### Invalid Field Sharing
+#### Invalid Field Sharing
 
 **Error Code**
 
@@ -3279,7 +3279,7 @@ type Subscription {
 }
 ```
 
-### Invalid Shareable Usage
+#### Invalid Shareable Usage
 
 **Error Code**
 
@@ -3336,7 +3336,7 @@ interface InventoryItem {
 }
 ```
 
-### Only Inaccessible Children
+#### Only Inaccessible Children
 
 **Error Code**  
 `ONLY_INACCESSIBLE_CHILDREN`
@@ -3487,7 +3487,7 @@ enum DeliveryStatus {
 }
 ```
 
-### Require Invalid Fields
+#### Require Invalid Fields
 
 **Error Code**
 
@@ -3578,7 +3578,7 @@ type Book {
 }
 ```
 
-### Provides Invalid Fields
+#### Provides Invalid Fields
 
 **Error Code**  
 `PROVIDES_INVALID_FIELDS`

--- a/spec/Section 4 -- Composition.md
+++ b/spec/Section 4 -- Composition.md
@@ -1795,6 +1795,84 @@ input FieldSelectionMap {
 }
 ```
 
+### Type Kind Mismatch
+
+**Error Code**  
+`TYPE_KIND_MISMATCH`
+
+**Severity**  
+ERROR
+
+**Formal Specification**
+
+- Let {schemas} be the set of all source schemas.
+- For each type name {typeName} defined in at least one of these schemas:
+  - Let {types} be the set of all types named {typeName} across all source
+    schemas.
+  - Let {typeKinds} be the set of
+    [type kinds](https://spec.graphql.org/October2021/#sec-Type-Kinds) in
+    {types}
+  - {typeKinds} must contain exactly one element.
+
+**Explanatory Text**
+
+Each named type must represent the **same** kind of GraphQL type across all
+source schemas. For instance, a type named `User` must consistently be an object
+type, or consistently be an interface, and so forth. If one schema defines
+`User` as an object type, while another schema declares `User` as an interface
+(or input object, union, etc.), the schema composition process cannot merge
+these definitions coherently.
+
+This rule ensures semantic consistency: a single type name cannot serve
+multiple, incompatible purposes in the final composed schema.
+
+**Examples**
+
+All schemas agree that `User` is an object type:
+
+```graphql
+# Schema A
+type User {
+  id: ID!
+  name: String
+}
+
+# Schema B
+type User {
+  id: ID!
+  email: String
+}
+
+# Schema C
+type User {
+  id: ID!
+  joinedAt: String
+}
+```
+
+In the following counter-example, `User` is defined as an object type in one of
+the schemas and as an interface in another. This violates the rule and results
+
+```graphql
+# Schema A: `User` is an object type
+type User {
+  id: ID!
+  name: String
+}
+
+# Schema B: `User` is an interface
+extend interface User {
+  id: ID!
+  friends: [User!]!
+}
+
+# Schema C: `User` is an input object
+extend input User {
+  id: ID!
+}
+```
+
+
 ### Merge
 
 ### Post Merge Validation

--- a/spec/Section 4 -- Composition.md
+++ b/spec/Section 4 -- Composition.md
@@ -850,6 +850,72 @@ type Query {
 }
 ```
 
+### Root Subscription Used
+
+**Error Code**
+
+`ROOT_SUBSCRIPTION_USED`
+
+**Severity**
+
+ERROR
+
+**Formal Specification**
+
+- Let {schemas} be the set of all source schemas.
+- For each {schema} in {schemas}:
+  - Let {rootSubscription} be the root mutation type defined in {schema}, if it
+    exists.
+  - Let {namedSubscriptionType} be the type with the name `Subscription` in
+    {schema}, if it exists.
+  - If {rootSubscription} is defined:
+    - {rootSubscription} must be named `Subscription`.
+  - Otherwise, {namedSubscriptionType} must not be defined.
+
+**Explanatory Text**
+
+This rule enforces that, for any source schema, if a root subscription type is
+defined, it must be named `Subscription`. Defining a root subscription type with
+a name other than `Subscription` or using a differently named type alongside a
+type explicitly named `Subscription` creates inconsistencies in schema design
+and violates the composite schema specification.
+
+**Examples**
+
+Valid example:
+
+```graphql example
+schema {
+  subscription: Subscription
+}
+
+type Subscription {
+  productCreated: Product
+}
+
+type Product {
+  id: ID!
+  name: String
+}
+```
+
+The following counter-example violates the rule because `RootSubscription` is
+used as the root subscription type, but a type named `Subscription` is also
+defined.
+
+```graphql counter-example
+schema {
+  subscription: RootSubscription
+}
+
+type RootSubscription {
+  productCreated: Product
+}
+
+type Subscription {
+  deprecatedField: String
+}
+```
 
 ### Merge
 

--- a/spec/Section 4 -- Composition.md
+++ b/spec/Section 4 -- Composition.md
@@ -1071,6 +1071,69 @@ type FullName {
 }
 ```
 
+### Key Fields Has Arguments
+
+**Error Code**
+
+`KEY_FIELDS_HAS_ARGS`
+
+**Severity**
+
+ERROR
+
+**Formal Specification**
+
+- Let {schema} be the set of all source schemas.
+  - Let {types} be the set of all object types that are annotated with the
+    `@key` directive in {schema}.
+  - For each {type} in {types}:
+    - Let {keyFields} be the set of fields referenced by the `fields` argument
+      of the `@key` directive on {type}.
+    - For each {field} in {keyFields}:
+      - HasKeyFieldsArguments(field) must be true.
+
+HasKeyFieldsArguments(field):
+
+- If {field} has arguments:
+  - return false
+- If {field} has a selection set:
+  - Let {subFields} be the set of all fields in the selection set of {field}.
+  - For each {subField} in {subFields}:
+    - HasKeyFieldsArguments(subField) must be true.
+- return true
+
+**Explanatory Text**
+
+The `@key` directive is used to define the set of fields that uniquely identify
+an entity. These fields must not include any field that is defined with
+arguments, as arguments introduce variability that prevents consistent and valid
+entity resolution across schemas. Fields included in the `fields` argument of
+the `@key` directive must be static and consistently resolvable.
+
+**Examples**
+
+In this example, the `User` type has a valid `@key` directive that references
+the argument-free fields `id` and `name`.
+
+```graphql example
+type User @key(fields: "id name") {
+  id: ID!
+  name: String
+  tags: [String]
+}
+```
+
+In this counter-example, the `@key` directive references a field (`tags`) that
+is defined with arguments (`limit`), which is not allowed.
+
+```graphql counter-example
+type User @key(fields: "id tags") {
+  id: ID!
+  tags(limit: Int = 10): [String]
+}
+```
+
+
 ### Merge
 
 ### Post Merge Validation

--- a/spec/Section 4 -- Composition.md
+++ b/spec/Section 4 -- Composition.md
@@ -1749,6 +1749,52 @@ type Author {
 }
 ```
 
+### Type Definition Invalid
+
+**Error Code**
+
+`TYPE_DEFINITION_INVALID`
+
+**Severity**
+
+ERROR
+
+**Formal Specification**
+
+- Let {schema} be one of the source schemas.
+- Let {types} be the set of built-in types (for example, `FieldSelectionMap`)
+  defined by the composition specification.
+- For each {type} in {types}:
+  - {type} must strictly equal the built-in type defined by the composition
+    specification.
+
+**Explanatory Text**
+
+Certain types are reserved in composite schema specification for specific
+purposes and must adhere to the specification’s definitions. For example,
+`FieldSelectionMap` is a built-in scalar that represents a selection of fields
+as a string. Redefining these built-in types with a different kind (e.g., an
+input object, enum, union, or object type) is disallowed and makes the
+composition invalid.
+
+This rule ensures that built-in types maintain their expected shapes and
+semantics so the composed schema can correctly interpret them.
+
+**Examples**
+
+In the following counter-example, `FieldSelectionMap` is declared as an `input`
+type instead of the required `scalar`. This leads to a `TYPE_DEFINITION_INVALID`
+error because the defined scalar `FieldSelectionMap` is being overridden by an
+incompatible definition.
+
+```graphql counter-example
+directive @require(field: FieldSelectionMap!) on ARGUMENT_DEFINITION
+
+input FieldSelectionMap {
+  fields: [String!]!
+}
+```
+
 ### Merge
 
 ### Post Merge Validation

--- a/spec/Section 4 -- Composition.md
+++ b/spec/Section 4 -- Composition.md
@@ -2134,6 +2134,68 @@ type Bill {
 }
 ```
 
+### Override on Interface
+
+**Error Code**  
+`OVERRIDE_ON_INTERFACE`
+
+**Severity**  
+ERROR
+
+**Formal Specification**
+
+- Let {schemas} be the set of all source schemas to be composed.
+- For each {schema} in {schemas}:
+  - Let {types} be the set of all interface types in {schema}.
+  - For each {type} in {types}:
+    - Let {fields} be the set of fields on {type}.
+    - For each {field} in {fields}:
+      - {field} must **not** be annotated with `@override`
+
+**Explanatory Text**
+
+The `@override` directive designates that ownership of a field is transferred
+from one source schema to another. In the context of interface types, fields are
+abstract—objects that implement the interface are responsible for providing the
+actual fields. Consequently, it is invalid to attach `@override` directly to an
+interface field. Doing so leads to an `OVERRIDE_ON_INTERFACE` error because
+there is no concrete field implementation on the interface itself that can be
+overridden.
+
+**Examples**
+
+In this valid example, `@override` is used on a field of an object type,
+ensuring that the field definition is concrete and can be reassigned to another
+schema.
+
+Since `@override` is **not** used on any interface fields, no error is produced.
+
+```graphql example
+# Source Schema A
+type Order {
+  id: ID!
+  amount: Int
+}
+
+# Source Schema B
+type Order {
+  id: ID!
+  amount: Int @override(from: "SchemaA")
+}
+```
+
+In the following counter-example, `Bill.amount` is declared on an **interface**
+type and annotated with `@override`. This violates the rule because the
+interface field itself is not eligible for ownership transfer. The composition
+fails with an `OVERRIDE_ON_INTERFACE` error.
+
+```graphql counter-example
+# Source Schema A
+interface Bill {
+  id: ID!
+  amount: Int @override(from: "SchemaB")
+}
+```
 
 ### Merge
 

--- a/spec/Section 4 -- Composition.md
+++ b/spec/Section 4 -- Composition.md
@@ -8,11 +8,35 @@ composition process is divided into three main steps: **Validate Source
 Schemas**, **Merge Source Schemas**, and **Validate Satisfiability**, which are
 run in sequence to produce the composite execution schema.
 
+Although this chapter describes schema composition as a sequence of phases, an
+implementation is not required to implement these steps exactly as presented.
+Implementations may interleave or reorder the specified checks, or introduce
+additional processing stages, provided that the final composed schema complies
+with the requirements set forth in this specification. The composition rules and
+resulting schema must remain consistent, but the specific structure or timing of
+each validation step is left to the implementer.
+
 ## Validate Source Schemas
+
+In this phase, each source schema is validated in isolation to ensure that it
+satisfies the GraphQL specification and composition requirements. No
+cross-schema references are considered here. Each source schema must have valid
+syntax, well-formed type definitions, and correct directive usage. If any source
+schema fails these checks, composition does not proceed.
 
 ## Merge Source Schemas
 
+Once all source schemas have passed individual validation, they are merged into
+a single composite schema. This merging process is subdivided into three stages:
+pre-merge validation, merge, and post-merge validation.
+
 ### Pre Merge Validation
+
+Prior to merging the schemas, additional validations are performed that require
+visibility into all source schemas but treat them as separate entities. This
+step detects conflicts such as incompatible fields or default argument values
+that would render the merged schema unusable. Detecting such conflicts early
+prevents errors that would otherwise be discovered during the merge process.
 
 #### Enum Type Default Value Uses Inaccessible Value
 
@@ -2690,7 +2714,19 @@ interface Node {
 
 ### Merge
 
+During this stage, all definitions from each source schema are combined into a
+single schema. This section defines the rules for merging schema definitions.
+The goal is to create a composite schema that includes all type system members
+from each source schema that are publicly accessible.
+
 ### Post Merge Validation
+
+After the schema is composed, there are certain validations that are only
+possible in the context of the fully merged schema. These validations verify
+overall consistency: for example, ensuring that no type is left without
+accessible fields, or that interfaces and their implementors remain compatible.
+This stage confirms that the combined schema remains coherent when considered as
+a whole.
 
 #### Empty Merged Object Type
 
@@ -3616,3 +3652,8 @@ type UserDetails {
 ```
 
 ## Validate Satisfiability
+
+The final step confirms that the composite schema supports executable queries
+without leading to invalid conditions. Each query path defined in the merged
+schema is checked to ensure that every field can be resolved. If any query path
+is unresolvable, the schema is deemed unsatisfiable, and composition fails.

--- a/spec/Section 4 -- Composition.md
+++ b/spec/Section 4 -- Composition.md
@@ -1133,6 +1133,66 @@ type User @key(fields: "id tags") {
 }
 ```
 
+### Key Invalid Syntax
+
+**Error Code**  
+`KEY_INVALID_SYNTAX`
+
+**Severity**  
+ERROR
+
+**Formal Specification**
+
+- Let {schemas} be the set of all source schemas.
+  - Let {types} be the set of all object or interface types in each {schema}.
+  - For each {type} in {types}:
+    - Let {keyDirectives} be the set of all `@key` directives on {type}.
+    - For each {keyDirective} in {keyDirectives}:
+      - Let {fieldsArg} be the string value of the `fields` argument of
+        {keyDirective}.
+      - Attempt to parse {fieldsArg} as a valid GraphQL selection set.
+      - Parsing must **not** fail (e.g., missing braces, invalid tokens,
+        unbalanced curly braces, or other syntax errors).
+
+**Explanatory Text**
+
+Each `@key` directive must specify the fields that uniquely identify an entity
+using a valid GraphQL selection set in its `fields` argument. If the `fields`
+argument string is syntactically incorrect—missing closing braces, containing
+invalid tokens, or otherwise malformed - it cannot be composed into a valid
+schema and triggers the `KEY_INVALID_SYNTAX` error.
+
+**Examples**
+
+In this valid scenario, the `fields` argument is a correctly formed selection
+set: `"sku featuredItem { id }"` is properly balanced and contains no syntax
+errors.
+
+```graphql example
+type Product @key(fields: "sku featuredItem { id }") {
+  sku: String!
+  featuredItem: Node!
+}
+
+interface Node {
+  id: ID!
+}
+```
+
+Here, the selection set `"featuredItem { id"` is missing the closing brace `}`.
+It is thus invalid syntax, causing a `KEY_INVALID_SYNTAX` error.
+
+```graphql counter-example
+type Product @key(fields: "featuredItem { id") {
+  featuredItem: Node!
+  sku: String!
+}
+
+interface Node {
+  id: ID!
+}
+```
+
 
 ### Merge
 

--- a/spec/Section 4 -- Composition.md
+++ b/spec/Section 4 -- Composition.md
@@ -1255,7 +1255,7 @@ IsValidKeyField(selection, type):
 **Explanatory Text**
 
 Even if the selection set for `@key(fields: "…")` is syntactically valid, field
-reference within that selection set must also refer to **actual** fields on the
+references within that selection set must also refer to **actual** fields on the
 annotated type. This includes nested selections, which must appear on the
 corresponding return type. If any referenced field is missing or incorrectly
 named, composition fails with a `KEY_INVALID_FIELDS` error because the entity

--- a/spec/Section 4 -- Composition.md
+++ b/spec/Section 4 -- Composition.md
@@ -2440,6 +2440,61 @@ type Book {
 }
 ```
 
+### Key Invalid Fields Type
+
+**Error Code**  
+`KEY_INVALID_FIELDS_TYPE`
+
+**Severity**  
+ERROR
+
+**Formal Specification**
+
+- Let {schemas} be the set of all source schemas to be composed.
+- For each {schema} in {schemas}:
+  - Let {types} be the set of all composite types in {schema}.
+  - For each {type} in {types}:
+    - If {type} is annotated with `@key`:
+      - Let {fieldsArg} be the value of the `fields` argument in the `@key`
+        directive.
+      - {fieldsArg} must be a string.
+
+**Explanatory Text**
+
+The `@key` directive designates the fields used to identify a particular object
+uniquely. The `fields` argument accepts a **string** that represents a selection
+set (for example, `"id"`, or `"id otherField"`). If the `fields` argument is
+provided as any non-string type (e.g., `Boolean`, `Int`, `Array`), the schema
+fails to compose correctly because it cannot parse a valid field selection.
+
+**Examples**
+
+In this example, the `@key` directive’s `fields` argument is the string
+`"id uuid"`, identifying two fields that form the object key. This usage is
+valid.
+
+```graphql example
+type User @key(fields: "id uuid") {
+  id: ID!
+  uuid: ID!
+  name: String
+}
+
+type Query {
+  users: [User]
+}
+```
+
+Here, the `fields` argument is provided as a boolean (`true`) instead of a
+string. This violates the directive requirement and triggers a
+`KEY_INVALID_FIELDS_TYPE` error.
+
+```graphql counter-example
+type User @key(fields: true) {
+  id: ID
+}
+```
+
 
 ### Merge
 


### PR DESCRIPTION
This PR adds 36 validation rules (pre and post merge) based on the federation error codes: https://www.apollographql.com/docs/graphos/reference/federation/errors

This PR is a successor of #61 

A list over which codes are implemented, skipped or postponed  can be found here:
https://github.com/graphql/composite-schemas-spec/pull/61/files
