### PR TITLE
Add validation for duplicate lookups.

### DIFF
--- a/spec/Section 2 -- Source Schema.md
+++ b/spec/Section 2 -- Source Schema.md
@@ -136,6 +136,23 @@ type Product @key(fields: "id") {
 }
 ```
 
+For a given subgraph, there must be only one lookup field that can resolve a given
+entity by a specific key. If multiple lookup fields are defined that resolve the
+same entity by the same key, the composition process must throw a composition
+error.
+
+```graphql counter-example
+type Query {
+  product(id: ID!): Product @lookup
+  productV2(id: ID!): Product @lookup
+}
+
+type Product @key(fields: "id") @key(fields: "sku") {
+  id: ID!
+  sku: String!
+}
+```
+
 Lookups can also be nested within other lookups and allow resolving nested
 entities that are part of an aggregate. In the following example the `Product`
 can be resolved by its ID but also the `ProductPrice` can be resolved by passing


### PR DESCRIPTION
Duplicate lookup fields creates ambiguity for the query planner