### PR TITLE
Minor corrections (part 4)

### DIFF
--- a/spec/Appendix A -- Field Selection.md
+++ b/spec/Appendix A -- Field Selection.md
@@ -422,11 +422,11 @@ operator is applied when mapping an abstract output type to a `@oneOf` input
 type.
 
 ```graphql example
-{ movieId: <Movie>.id } | { productId: <Product>.id }
+{ bookId: <Book>.id } | { movieId: <Movie>.id }
 ```
 
 ```graphql example
-{ nested: { movieId: <Movie>.id } | { productId: <Product>.id }}
+{ nested: { bookId: <Book>.id } | { movieId: <Movie>.id } }
 ```
 
 ### SelectedObjectValue
@@ -649,9 +649,13 @@ input FindMediaInput @oneOf {
   movieId: ID
 }
 
-type SearchStoreInput {
+input SearchStoreInput {
   city: String
   hasInStock: FindMediaInput
+}
+
+input Nested {
+  nested: FindMediaInput
 }
 ```
 
@@ -683,9 +687,9 @@ title
 <Book>.title
 ```
 
-Incorrect paths where the field does not exist on the specified type is not
-valid result in validation errors. For instance, if `<Book>.movieId` is
-referenced but `movieId` is not a field of `Book`, will result in an invalid
+Incorrect paths where the field does not exist on the specified type are not
+valid and result in validation errors. For instance, if `<Book>.movieId` is
+referenced but `movieId` is not a field of `Book`, it will result in an invalid
 {Path}.
 
 ```graphql counter-example
@@ -721,26 +725,26 @@ For example, the following {Path} is valid if `title` is a scalar field on the
 `Book` type:
 
 ```graphql example
-book.title
+title
 ```
 
 The following {Path} is invalid because `title` should not have subselections:
 
 ```graphql counter-example
-book.title.something
+title.something
 ```
 
 For non-leaf fields, the {Path} must continue to specify subselections until a
 leaf field is reached:
 
 ```graphql example
-book.author.id
+author.id
 ```
 
 Invalid {Path} where non-leaf fields do not have further selections:
 
 ```graphql counter-example
-book.author
+author
 ```
 
 ### Type Reference Is Possible
@@ -797,7 +801,7 @@ type Store {
 }
 ```
 
-Non-coercible values are invalid. The following examples are invalid:
+Non-coercible values are invalid. The following example is invalid:
 
 ```graphql counter-example
 type Query {

--- a/spec/Section 2 -- Source Schema.md
+++ b/spec/Section 2 -- Source Schema.md
@@ -505,7 +505,7 @@ one distinct unique key for that entity, which enables a gateway to perform
 lookups and resolve instances of the entity based on that key.
 
 ```graphql example
-type Product @key(fields: "id") @key(fields: "key") {
+type Product @key(fields: "id") @key(fields: "sku") {
   id: ID!
   sku: String!
   name: String!

--- a/spec/Section 4 -- Composition.md
+++ b/spec/Section 4 -- Composition.md
@@ -4772,11 +4772,11 @@ type Product {
 ```
 
 ```graphql
+# Schema B
 type Query {
   review(id: ID!): Review
 }
 
-# Schema B
 type Review {
   id: ID!
   content: String
@@ -5708,8 +5708,8 @@ type Author {
 }
 ```
 
-In this counter-example, the `@require` directive references a field (`unknown`)
-that does not exist on the parent type (`Book`), causing a
+In this counter-example, the `@require` directive references a field
+(`unknownField`) that does not exist on the parent type (`Book`), causing a
 `REQUIRE_INVALID_FIELDS` error.
 
 ```graphql counter-example


### PR DESCRIPTION
Note: I've added an input type named `Nested` to the schema in section [6.3](https://graphql.github.io/composite-schemas-spec/draft/#sec-Validation) in order to support this example:

```graphql
{ nested: { movieId: <Movie>.id } | { productId: <Product>.id } }
```

Let me know if you'd like that to be handled differently.