### PR TITLE
Fix minor error in Composition.md

### DIFF
--- a/spec/Section 4 -- Composition.md
+++ b/spec/Section 4 -- Composition.md
@@ -388,7 +388,7 @@ ERROR
 
 **Formal Specification**
 
-- Let {rootQuery} be the root mutation type defined in the schema, if it exists.
+- Let {rootQuery} be the root query type defined in the schema, if it exists.
 - Let {namedQueryType} be the type with the name `Query` in {schema}, if it
   exists.
 - If {rootQuery} is defined:


### PR DESCRIPTION
The validation is about the root query type, so I assume defining rootQuery as the mutation root is an error.