### PR TITLE
Update `@shareable` rules

### DIFF
--- a/spec/Section 4 -- Composition.md
+++ b/spec/Section 4 -- Composition.md
@@ -3318,7 +3318,7 @@ ERROR
 - Let {typeNames} be the set of all object type names from all source schemas
   that are not declared as `@internal`
 - For each {typeName} in {typeNames}:
-  - Let {typeDefinitions} be the list of all type definitions from different
+  - Let {typeDefinitions} be the list of all object type definitions from all
     source schemas with the name {typeName}.
   - Let {fieldNames} be the set of all field names from all {typeDefinitions}
     that are not declared as `@internal` or `@external`, part of a `@key`


### PR DESCRIPTION
https://github.com/graphql/composite-schemas-spec/issues/147#issuecomment-3323462098

> Based on an internal discussion:
> 
> 1. We'll move this to a pre-merge validation rule.
> 2. We'll move the "subscription root fields cannot be shared" part to INVALID_SHAREABLE_USAGE.
> 3. We'll update "excluding fields marked with `@external` or `@override`" to clarify that it's the overridden field, not the overriding field, that is excluded.
> 4. We'll update the spec to require all source schemas to mark the field as shareable, not just one of them.
> 5. We'll simplify the counter-example.