### PR TITLE
Define how selection maps produce values at runtime

### DIFF
--- a/spec/Appendix A -- Field Selection.md
+++ b/spec/Appendix A -- Field Selection.md
@@ -647,6 +647,94 @@ input LocationInput {
 }
 ```
 
+### Value Production
+
+At runtime, the _distributed GraphQL executor_ evaluates a {FieldSelectionMap}
+against a runtime object to derive input values. Evaluation of a {SelectedValue}
+either _produces a value_ or _produces no value_.
+
+A {Path} produces no value if a type condition within the {Path} does not match
+the runtime type of the object it is applied to, or if a field on an
+intermediate segment of the {Path} resolves to {null}. Otherwise, the {Path}
+produces the value of the field selected by its final segment, which may itself
+be {null}.
+
+The alternatives of a {SelectedValue} joined by the pipe (`|`) operator are
+evaluated in the order they are declared, and the {SelectedValue} produces the
+value of the first alternative that produces a value. If no alternative produces
+a value, the {SelectedValue} produces no value.
+
+How the alternatives are planned depends on the directive that uses the
+{FieldSelectionMap}. In a `@require` selection map, the alternatives form a
+fallback chain: the query plan fetches the data for every alternative, and the
+runtime data alone decides which alternative produces the value. In an `@is`
+selection map, the alternatives represent alternative stable keys for entering a
+source schema: any one alternative is sufficient, and the query planner selects
+among the alternatives based on what is resolvable in the current context.
+
+Type conditions within a {SelectedValue} are not required to cover every
+possible runtime type of an abstract type. A runtime object whose type is not
+covered by any alternative results in the {SelectedValue} producing no value.
+
+In the following example, the {SelectedValue} produces the value of `isbn` if
+the runtime type of the media object is `Book` and the value of `releaseDate` if
+the runtime type is `Movie`. For a runtime type covered by neither alternative,
+the {SelectedValue} produces no value.
+
+```graphql example
+<Book>.isbn | <Movie>.releaseDate
+```
+
+For a {SelectedObjectValue}, each selected object field whose {SelectedValue}
+produces a value contributes that value to the resulting input object value. If
+a selected object field produces no value and the corresponding input object
+field is optional (nullable or with a default value), the field is omitted from
+the resulting input object value. If a selected object field produces no value
+and the corresponding input object field is required (non-null without a default
+value), the enclosing {SelectedObjectValue} produces no value. A
+{SelectedObjectValue} in which no selected object field produces a value
+produces no value.
+
+If the expected input type is a OneOf Input Object, the {SelectedObjectValue}
+produces a value only if exactly one selected object field produces a value and
+that value is not {null}; otherwise, the {SelectedObjectValue} produces no
+value. This matches the requirement that exactly one field of a OneOf Input
+Object must be set and non-null.
+
+In the following example, evaluated against a runtime object of type `Movie`,
+the first alternative produces no value: `bookId` produces no value because the
+type condition does not match, and no other selected field produces a value.
+Evaluation falls through to the second alternative, which produces the input
+object `{ movieId: ... }`.
+
+```graphql example
+{ bookId: <Book>.id } | { movieId: <Movie>.id }
+```
+
+For a {Path} followed by a {SelectedObjectValue}, such as
+`dimension.{ size, weight }`, the {SelectedObjectValue} is evaluated against the
+object selected by the {Path}. If the field selected by the {Path} resolves to
+{null}, the selection produces the value {null}.
+
+For a {Path} followed by a {SelectedListValue}, such as `parts[id]`, the value
+of the field selected by the {Path} determines the result. If the field resolves
+to {null}, the selection produces the value {null}. Otherwise, the inner
+selection of the {SelectedListValue} is evaluated for each element of the
+runtime list, producing a list of the same length: a {null} element produces
+{null} at its position, and an element for which the inner selection produces
+{null} or no value also produces {null} at its position. Elements are never
+omitted, so the produced list always has the same length as the runtime list.
+For nested lists, these rules apply recursively to each level of the list.
+
+Note: A produced value is subject to the standard input coercion rules when it
+is applied. A produced {null} - for example, a {null} list element - is only
+valid where the corresponding input type permits {null}.
+
+The effect of a {FieldSelectionMap} that produces no value depends on the
+directive that uses it. For example, an argument annotated with `@require` whose
+selection map produces no value is treated as if the argument had not been
+provided.
+
 ## Validation
 
 Validation ensures that {FieldSelectionMap} scalars are semantically correct

--- a/spec/Section 2 -- Source Schema.md
+++ b/spec/Section 2 -- Source Schema.md
@@ -365,6 +365,15 @@ input PersonByInput @oneOf {
 }
 ```
 
+The alternatives of an `@is` selection map represent alternative stable keys -
+entry requirements for resolving an entity in this source schema. Any one of the
+keys is sufficient to enter the source schema. In contrast to `@require`, where
+the executor fetches the data for all alternatives and the runtime data decides
+which value is used, the query planner selects which alternative it uses based
+on the data it can resolve in the current context. A lookup field is usable as
+long as at least one alternative can be resolved (see
+[Validate Satisfiability](#sec-Validate-Satisfiability)).
+
 **Arguments:**
 
 - `field`: Represents a selection path map syntax.
@@ -441,6 +450,33 @@ input ProductDimensionInput {
   productWeight: Int!
 }
 ```
+
+**Runtime Behavior**
+
+At runtime, the _distributed executor_ first fetches the data for all
+alternatives of the selection map and only then evaluates the map against the
+fetched data to derive the argument value (see
+[Value Production](#sec-Value-Production)). Which alternative supplies the value
+is decided by the runtime data, not by the query planner; the query plan
+requests the data for every alternative. The selection map may produce no value
+for a given runtime object, for example, because a type condition does not match
+the object's runtime type or because a field on an intermediate segment of the
+selected path resolves to null.
+
+If the selection map produces no value, the annotated argument is treated as if
+it had not been provided, and the standard GraphQL argument coercion rules
+apply: if the argument defines a default value, the default value is used; if
+the argument is nullable, it remains unprovided. If the argument is non-null and
+does not define a default value, the requirement cannot be satisfied and the
+field cannot be invoked; a field error is raised for the annotated field and is
+handled according to the standard GraphQL error propagation rules.
+
+Note: Type conditions in a selection map are not required to cover every
+possible runtime type of an abstract type. However, for a non-null argument
+without a default value, an uncovered runtime type means that the annotated
+field always results in a field error for objects of that type. Schema authors
+should cover all possible runtime types, make the argument nullable, or provide
+a default value.
 
 **Arguments:**
 

--- a/spec/Section 4 -- Composition.md
+++ b/spec/Section 4 -- Composition.md
@@ -6787,8 +6787,11 @@ in {schema} is annotated with `@require`.
 
 ResolveRequirements(sourceSchema, targetSchema, type, field, allSchemas):
 
-Each `@require` argument on {field} must be resolvable from allowed schemas
-(excluding {targetSchema}) when execution starts from {sourceSchema}.
+Every alternative of each `@require` argument's selection map on {field} must be
+resolvable from allowed schemas (excluding {targetSchema}) when execution starts
+from {sourceSchema}. The _distributed GraphQL executor_ fetches the data for all
+alternatives before evaluating which value is injected into the argument; an
+alternative that cannot be resolved is therefore a satisfiability error.
 
 - Let {allowedSchemas} be {allSchemas} excluding {targetSchema}.
 - Let {requiredArguments} be the set of arguments on {field} that are annotated
@@ -6798,14 +6801,10 @@ Each `@require` argument on {field} must be resolvable from allowed schemas
     {requiredArgument}.
   - Let {requirementPathSets} be
     `ExtractPathSets(fieldSelectionMap, type, requiredArgument)`.
-  - Let {argumentSatisfied} be false.
   - For each {requirementPathSet} in {requirementPathSets}:
     - If `IsPathSetResolvable(requirementPathSet, sourceSchema, allowedSchemas)`
-      is true:
-      - Set {argumentSatisfied} to true.
-      - Break.
-  - If {argumentSatisfied} is false:
-    - return false.
+      is false:
+      - return false.
 - return true.
 
 LookupPathSets(lookup, rootType):
@@ -6868,9 +6867,20 @@ can themselves be resolved from the current schema context.
 
 Likewise, if a field declares `@require` dependencies, those dependencies must
 also be resolvable from schemas other than the one defining that requirement.
-`FieldSelectionMap` alternatives are handled as path-set alternatives where at
-least one alternative must resolve. If no alternative resolves, that candidate
-schema is removed from the options for that path step.
+The alternatives of a `@require` selection map form a fallback chain that is
+evaluated against runtime data: the _distributed GraphQL executor_ first fetches
+the data for all alternatives and only then evaluates which value is injected
+into the argument - the first alternative that produces a value (see Appendix A,
+Value Production). Which alternative applies is decided by the runtime data, not
+by the query planner. Every alternative must therefore be resolvable; if any
+alternative cannot be resolved, that candidate schema is removed from the
+options for that path step.
+
+The alternatives of an `@is` selection map on a lookup field, in contrast,
+represent alternative stable keys for entering a source schema. Any one of them
+is sufficient: the query planner selects an alternative that is resolvable from
+the current context. This is reflected in {IsReachable}, where a single
+resolvable lookup path set makes the target schema reachable.
 
 If every candidate is eliminated for any field path, the path is unsatisfiable
 and composition fails with `UNSATISFIABLE_QUERY_PATH`.


### PR DESCRIPTION
Adds a Value Production section to Appendix A defining how a `FieldSelectionMap` is evaluated against runtime data, defines the `@require` runtime behavior (fetch all alternatives, evaluate first match, missing value falls back to argument coercion), and distinguishes `@require` fallback chains from `@is` entry keys in satisfiability. Part of #222.