### PR TITLE
@provides is an optimization, never a requirement

### DIFF
--- a/spec/Section 2 -- Source Schema.md
+++ b/spec/Section 2 -- Source Schema.md
@@ -740,7 +740,7 @@ type Query {
 The `@provides` directive is an execution-time optimization and never a
 requirement for resolvability. Composition validates that every query path of
 the composite schema remains satisfiable with all `@provides` directives
-ignored. A `@provides` allows the _distributed GraphQL executor_ to obtain the
+ignored. A `@provides` directive allows the _distributed GraphQL executor_ to obtain the
 selected fields in the same response and thereby reduce the number of source
 schema requests, but the selected fields must remain resolvable without it.
 

--- a/spec/Section 2 -- Source Schema.md
+++ b/spec/Section 2 -- Source Schema.md
@@ -740,9 +740,10 @@ type Query {
 The `@provides` directive is an execution-time optimization and never a
 requirement for resolvability. Composition validates that every query path of
 the composite schema remains satisfiable with all `@provides` directives
-ignored. A `@provides` directive allows the _distributed GraphQL executor_ to obtain the
-selected fields in the same response and thereby reduce the number of source
-schema requests, but the selected fields must remain resolvable without it.
+ignored. A `@provides` directive allows the _distributed GraphQL executor_ to
+obtain the selected fields in the same response and thereby reduce the number of
+source schema requests, but the selected fields must remain resolvable without
+it.
 
 **Arguments:**
 

--- a/spec/Section 2 -- Source Schema.md
+++ b/spec/Section 2 -- Source Schema.md
@@ -737,6 +737,13 @@ type Query {
 }
 ```
 
+The `@provides` directive is an execution-time optimization and never a
+requirement for resolvability. Composition validates that every query path of
+the composite schema remains satisfiable with all `@provides` directives
+ignored. A `@provides` allows the _distributed GraphQL executor_ to obtain the
+selected fields in the same response and thereby reduce the number of source
+schema requests, but the selected fields must remain resolvable without it.
+
 **Arguments:**
 
 - `fields`: Represents a field selection set syntax describing the subfields of
@@ -793,6 +800,14 @@ field is provided by another source schema. The current source schema references
 it only for entity identification (via `@key`) or for providing a field through
 `@provides`. If no such usage exists, the presence of an `@external` field
 produces a composition error.
+
+The _distributed GraphQL executor_ never requests a field marked `@external`
+from the declaring source schema directly. The field is resolved either by a
+source schema that defines it without `@external`, or - when reached through a
+field annotated with `@provides` - as part of the providing source schema's
+response. The value of an external key field may also be known to the executor
+without resolving the field, for example, when it was used as the input of a
+lookup field that resolved the entity.
 
 ## @override
 

--- a/spec/Section 4 -- Composition.md
+++ b/spec/Section 4 -- Composition.md
@@ -6720,7 +6720,8 @@ elements via `RefinePlanOptions`.
 - Let ({initialType}, {initialField}) be the first element in {pathElements}.
 - Let {initialOptions} be an empty set.
 - For each {schema} in {allSchemas}:
-  - If {schema} defines {initialField} on {initialType}:
+  - If {schema} defines {initialField} on {initialType} and does not annotate it
+    with `@external`:
     - Add {schema} to {initialOptions}.
 - If {initialOptions} is empty:
   - return an empty set.
@@ -6740,6 +6741,9 @@ remainder of the path.
 - For each {currentSchema} in {currentOptions}:
   - For each {candidateSchema} in {allSchemas}:
     - If {candidateSchema} does not define {currentField} on {currentType}:
+      - Continue to the next {candidateSchema}.
+    - If {currentField} on {currentType} is annotated with `@external` in
+      {candidateSchema}:
       - Continue to the next {candidateSchema}.
     - If {candidateSchema} is not equal to {currentSchema}:
       - If
@@ -6874,6 +6878,18 @@ schema is removed from the options for that path step.
 
 If every candidate is eliminated for any field path, the path is unsatisfiable
 and composition fails with `UNSATISFIABLE_QUERY_PATH`.
+
+A source schema defines a field marked with `@external` but does not resolve it;
+external fields are therefore never resolution candidates in the source schema
+that declares them.
+
+The `@provides` directive is an execution-time optimization that allows a source
+schema to return external fields as part of the same response when resolving the
+annotated field. Each `@provides` selection must itself be deliverable by the
+providing source schema, which is enforced by the `@provides` validation rules.
+Query-path satisfiability, however, is evaluated as if all `@provides`
+directives were ignored: a `@provides` may reduce the number of fetches in a
+query plan, but must never be required to make a query path satisfiable.
 
 **Examples**
 


### PR DESCRIPTION
Query-path satisfiability is evaluated as if all `@provides` directives were stripped, and a field marked `@external` is never a resolution candidate in its declaring source schema. Part of #222.